### PR TITLE
Make .image() use the transformation matrix.

### DIFF
--- a/src/p5.RendererSVG.js
+++ b/src/p5.RendererSVG.js
@@ -127,7 +127,11 @@ export default function(p5) {
                 sHeight /= this._pInst._pixelDensity;
                 elt.setAttribute('viewBox', [sx, sy, sWidth, sHeight].join(', '));
             }
-            this.appendChild(elt);
+
+            let g = p5.SVGElement.create('g');
+            this.drawingContext.__applyTransformation(g.elt);
+            g.elt.appendChild(elt);
+            this.appendChild(g.elt);
         } else {
             p5.Renderer2D.prototype.image.apply(this, arguments);
         }


### PR DESCRIPTION
When drawing another SVG file passing the output of `createGraphics()` to `image()`, the current transformation matrix is not being taken into account. Because the `transform` attribute cannot be applied to the root `svg` element, this instead wraps such elements into a `g`.