### PR TITLE
#255 Examples are broken - Update versions

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <head>
     <meta charset="UTF-8">
-    <script src="https://unpkg.com/p5@1.4.1/lib/p5.js"></script>
-    <script src="https://unpkg.com/p5.js-svg@1.4.0"></script>
+    <script src="https://unpkg.com/p5@1.6.0/lib/p5.js"></script>
+    <script src="https://unpkg.com/p5.js-svg@1.5.1"></script>
     <script src="https://unpkg.com/abcjs@6.0.0-beta.33/dist/abcjs-basic-min.js"></script>
     <script src="lib/rainbow.js"></script>
     <link rel="stylesheet" type="text/css" href="lib/rainbow.css">

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,7 +2,7 @@
 <head>
     <meta charset="UTF-8">
     <script src="https://unpkg.com/p5@1.4.1/lib/p5.js"></script>
-    <script src="../dist/p5.svg.js"></script>
+    <script src="https://unpkg.com/p5.js-svg@1.4.0"></script>
     <script src="https://unpkg.com/abcjs@6.0.0-beta.33/dist/abcjs-basic-min.js"></script>
     <script src="lib/rainbow.js"></script>
     <link rel="stylesheet" type="text/css" href="lib/rainbow.css">


### PR DESCRIPTION
../dist/p5.svg.js returns a 404
instead, use the unpkg link https://unpkg.com/p5.js-svg@1.5.1 recommended in [README.md](https://github.com/zenozeng/p5.js-svg/blob/main/README.md) and update p5js to the recommended version in the readme as well